### PR TITLE
Add multi-arch build support

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,48 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
+      - name: Extract Jenkins inbound agent version from Dockerfile
+        id: get_version
+        run: |
+          version=$(grep -oP 'FROM\s+[^\s:]+:\K[^\s]+' Dockerfile)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Log the extracted version
+        run: echo "Jenkins inbound agent version is ${{ steps.get_version.outputs.version }}"
+
+      - name: Log in to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push multi-platform Docker image (version + latest)
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.version }} \
+            --tag ghcr.io/${{ github.repository }}:latest \
+            --push \
+            .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,76 +3,38 @@ FROM jenkins/inbound-agent:3283.v92c105e0f819-7
 # Switch to root to install additional packages
 USER root
 
+# TARGETARCH is provided automatically when building with BuildKit. Fallback to
+# the runtime architecture when building without it.
+ARG TARGETARCH
+
 # Update package lists and install prerequisites, including Python and pip.
-RUN apt-get update && apt-get install -y \
-    apt-transport-https \
-    curl \
-    gnupg \
-    lsb-release \
-    software-properties-common \
-    jq \
-    python3 \
-    python3-pip \
-    bat \
-    bridge-utils \
-    btop \
-    cpu-checker \
-    dnsutils \
-    duf \
-    ethtool \
-    fd-find \
-    gh \
-    git \
-    htop \
-    ifupdown \
-    iotop \
-    iperf3 \
-    iptables \
-    libvirt-clients \
-    libvirt-daemon-system \
-    lshw \
-    lsof \
-    make \
-    default-mysql-client \
-    nano \
-    net-tools \
-    netcat-openbsd \
-    neovim \
-    nfs-common \
-    nmap \
-    open-iscsi \
-    parted \
-    postgresql-client \
-    python3-venv \
-    qemu-guest-agent \
-    qemu-kvm \
-    qemu-system \
-    qemu-system-x86 \
-    ripgrep \
-    rsync \
-    screen \
-    smartmontools \
-    strace \
-    tcpdump \
-    tmux \
-    traceroute \
-    tree \
-    ufw \
-    unzip \
-    util-linux \
-    vim \
-    virtinst \
-    wget \
-    whois \
-    xorriso \
-    zip
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    apt-get update; \
+    packages="apt-transport-https curl gnupg lsb-release software-properties-common jq python3 python3-pip bat bridge-utils btop cpu-checker dnsutils duf ethtool fd-find gh git htop ifupdown iotop iperf3 iptables libvirt-clients libvirt-daemon-system lshw lsof make default-mysql-client nano net-tools netcat-openbsd neovim nfs-common nmap open-iscsi parted postgresql-client python3-venv qemu-guest-agent qemu-kvm qemu-system ripgrep rsync screen smartmontools strace tcpdump tmux traceroute tree ufw unzip util-linux vim virtinst wget whois xorriso zip"; \
+    case "$arch" in \
+      amd64|x86_64) packages="$packages qemu-system-x86" ;; \
+      arm64|aarch64) ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    apt-get install -y $packages; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
 
 # Install boto3 and botocore via pip, overriding system restrictions.
 RUN pip3 install --break-system-packages boto3 botocore
 
 # Add the HashiCorp GPG key and repository (Terraform + Packer come from here)
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "$arch" in \
+      amd64|x86_64) repo_arch="amd64" ;; \
+      arm64|aarch64) repo_arch="arm64" ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /usr/share/keyrings; \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg; \
+    echo "deb [arch=${repo_arch} signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list
 
 # Install Terraform, Packer, and Ansible
 RUN apt-get update && apt-get install -y \
@@ -82,8 +44,15 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install MinIO Client
-RUN curl -sSL https://dl.min.io/client/mc/release/linux-amd64/mc -o mc && \
-    chmod +x mc && mv mc /usr/local/bin/
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "$arch" in \
+      amd64|x86_64) mc_arch="amd64" ;; \
+      arm64|aarch64) mc_arch="arm64" ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -sSL "https://dl.min.io/client/mc/release/linux-${mc_arch}/mc" -o /usr/local/bin/mc; \
+    chmod +x /usr/local/bin/mc
 
 # Switch back to the default (jenkins) user
 USER jenkins


### PR DESCRIPTION
## Summary
- update the Jenkins agent Dockerfile to detect the active architecture for package installs, HashiCorp repository configuration, and MinIO client downloads
- add a reusable GitHub Actions workflow that builds and pushes multi-architecture images for amd64 and arm64

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d069f1cbfc832c876dacd2141c63aa