### PR TITLE
Fix CI builds for merged PRs

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -17,6 +17,12 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract Jenkins version from Dockerfile
         id: get_version
         run: |
@@ -30,16 +36,11 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build and push Docker image (version + latest)
+      - name: Build and push multi-platform Docker image (version + latest)
         run: |
-          # Build with two tags: versioned and latest
-          docker build \
-            -t ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.version }} \
-            -t ghcr.io/${{ github.repository }}:latest \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.version }} \
+            --tag ghcr.io/${{ github.repository }}:latest \
+            --push \
             .
-
-          # Push the versioned tag
-          docker push ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.version }}
-
-          # Push the latest tag
-          docker push ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
-  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- ensure the publish workflow only runs after changes land on main (merged PRs)
- build the dispatchable workflow image with buildx so both amd64 and arm64 variants are published

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d07382ad30832c9d06892ae8271dd5